### PR TITLE
Upgrade Swagger to 0.1.36

### DIFF
--- a/NCS.DSS.WebChat.Tests/NCS.DSS.WebChat.Tests.csproj
+++ b/NCS.DSS.WebChat.Tests/NCS.DSS.WebChat.Tests.csproj
@@ -4,8 +4,12 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Remove="Properties\**" />
+    <EmbeddedResource Remove="Properties\**" />
+    <None Remove="Properties\**" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="DFC.JSON.Standard" Version="0.1.4" />
-    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.30" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0-release-24373-02" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NUnit" Version="4.1.0" />
@@ -16,8 +20,5 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NCS.DSS.WebChat\NCS.DSS.WebChat.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
   </ItemGroup>
 </Project>

--- a/NCS.DSS.WebChat/NCS.DSS.WebChat.csproj
+++ b/NCS.DSS.WebChat/NCS.DSS.WebChat.csproj
@@ -10,12 +10,9 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="local.settings.json" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.2" />
     <PackageReference Include="DFC.HTTP.Standard" Version="0.1.11" />
-    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.30" />
+    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.36" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />


### PR DESCRIPTION
1. Removed Swagger References from Tests Project
2. Upgraded Swagger package from 0.1.30 to 0.1.36
3. Removed unnecessary file / folder references in projects